### PR TITLE
Silent/unattended mode for BCUA Remover #2

### DIFF
--- a/main.bat
+++ b/main.bat
@@ -26,7 +26,7 @@ REM                   and System32 drivers.
 REM                 - Removes Unified Agent entries from the Uninstall registry.
 REM                 - Prompts the user to restart the computer to complete removal.
 REM
-REM Usage       : Run as administrator. Follow the on-screen prompt to restart or exit.
+REM Usage       : Run as administrator. Follow the on-screen prompts.
 REM
 REM Note        : This script is based on the official BCUA removal instructions.
 REM               (https://knowledge.broadcom.com/external/article/169376/manually-uninstall-unified-agent.html)

--- a/main.bat
+++ b/main.bat
@@ -44,6 +44,16 @@ if %errorlevel% neq 0 (
     exit /b
 )
 
+REM Parse command-line arguments for silent mode
+for %%i in (%*) do (
+    REM Check for "-" arguments
+    if /I "%%i"=="--silent" set "BCUA_SILENT=1"
+    if /I "%%i"=="-s" set "BCUA_SILENT=1"
+    REM Check for "/" arguments
+    if /I "%%i"=="/silent" set "BCUA_SILENT=1"
+    if /I "%%i"=="/s" set "BCUA_SILENT=1"
+)
+
 REM Remove registry keys (manual uninstall)
 reg delete "HKLM\SYSTEM\CurrentControlSet\services\bc-cloud-wfp" /f >nul 2>&1
 reg delete "HKLM\SYSTEM\CurrentControlSet\services\bcua-service" /f >nul 2>&1
@@ -71,6 +81,7 @@ for /f "tokens=*" %%k in ('reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVer
 )
 
 echo Unified Agent removal steps complete.
+if "%BCUA_SILENT%"=="1" goto :END_SCRIPT
 echo It is recommended to restart your computer to complete the removal.
 :RESTART_PROMPT
 echo Press Y to restart now, or N to exit without restarting.

--- a/tests/silent_argument.bat
+++ b/tests/silent_argument.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Test script for BCUA_SILENT argument logic
+
+set "BCUA_SILENT=0"
+for %%i in (%*) do (
+    REM Check for "-" arguments
+    if /I "%%i"=="--silent" set "BCUA_SILENT=1"
+    if /I "%%i"=="-s" set "BCUA_SILENT=1"
+    REM Check for "/" arguments
+    if /I "%%i"=="/silent" set "BCUA_SILENT=1"
+    if /I "%%i"=="/s" set "BCUA_SILENT=1"
+)
+
+echo Arguments received: %*
+echo BCUA_SILENT=%BCUA_SILENT%
+
+pause


### PR DESCRIPTION
### Added

- **Silent Mode Argument Support:**  
  The script now supports multiple command-line flags for silent/unattended operation. You can use any of the following arguments to enable silent mode:
  - `--silent`
  - `-s`
  - `/silent`
  - `/s`

  When any of these flags are present, the script sets the `BCUA_SILENT` variable to `1` and suppresses all user prompts, including the reboot prompt at the end of the removal process.

### Changed

- **Argument Parsing Logic:**  
  The batch file now iterates through all provided arguments and checks for the above silent mode flags in a case-insensitive manner. This ensures compatibility with different flag styles and improves usability for automation and scripting scenarios.

### Usage

- To run the remover in silent mode (no prompts), use:
  ```
  main.bat --silent
  ```
  or
  ```
  main.bat -s
  ```
  or
  ```
  main.bat /silent
  ```
  or
  ```
  main.bat /s
  ```

### Notes

- The default interactive behavior is unchanged if no silent flag is provided.
- This update improves support for automated deployments and scripting environments.